### PR TITLE
chore: use github action to build and publish latest npm package on every day morning (master branch)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '30 3 * * *'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - run: npm run build
+      - name: publish with tag to npm
+        id: publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          echo "//registry.yarnpkg.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+          tag="${GITHUB_REF##*/}"
+          [[ "$tag" == "master" ]] && tag="latest"
+          echo "Publish with tag: $tag"
+          npm publish -q --tag "$tag" || true
+       

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "./scripts/build"
   },
   "devDependencies": {
-    "workbox-cli": "^5.1.4"
+    "workbox-cli": "latest"
   },
   "contributors": [
     {


### PR DESCRIPTION
The latest workbox-sw has been released with 6.3.0. This repo's workbox-cli is locked on "^5.x.x". It's outdated.